### PR TITLE
Allow react ^17.0.0 as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "sinon": "^2.0"
   },
   "peerDependencies": {
-    "react": "~0.14.8 || ^15.0.0 || ^16.0.0"
+    "react": "~0.14.8 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "babel-runtime": "6.26.0",


### PR DESCRIPTION
I'm using this component in a react 17 application without any issues. However, with the new NPM peer dependency policy, I can only install it using the `--force` flag which is inconvenient.

I suggest to allow React 17 as peer dependency to remove this issue. Would you agree to merge this PR ?